### PR TITLE
Expired login tokens trigger "login again" message

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -8,6 +8,8 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Session\TokenMismatchException;
+use Session;
 
 class Handler extends ExceptionHandler
 {
@@ -21,6 +23,7 @@ class Handler extends ExceptionHandler
         HttpException::class,
         ModelNotFoundException::class,
         ValidationException::class,
+        TokenMismatchException::class,    
     ];
 
     /**
@@ -45,6 +48,10 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
+        if ($e instanceof TokenMismatchException) {
+            Session::flash('error_message', 'Your login session has expired. Please login again');
+            return redirect('/login');
+        }
         return parent::render($request, $e);
     }
 }

--- a/config/queue.php
+++ b/config/queue.php
@@ -94,7 +94,7 @@ return [
     |
     */
     'jobLimits' => [
-        'queue_cap' => 2, //set to null to remove the cap
+        'queue_cap' => 10, //set to null to remove the cap
     ],
 
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -10,6 +10,11 @@
                     <form class="form-horizontal" role="form" method="POST" action="{{ url('/login') }}">
                         {{ csrf_field() }}
 
+                        @if(Session::has('error_message'))
+                            <div class="alert alert-danger w-100" role="alert">
+                                {{ Session::get('error_message') }}
+                            </div>
+                        @endif
                         <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
                             <label for="email" class="col-md-4 control-label">E-Mail Address</label>
 


### PR DESCRIPTION
The user is redirected to the login page where the error is displayed.
Logging of the token expire is suppressed.
Additionally the queuecap value is set to the correct default 10.