### PR TITLE
Feature/handle no file

### DIFF
--- a/app/Http/Controllers/FumaController.php
+++ b/app/Http/Controllers/FumaController.php
@@ -482,11 +482,14 @@ class FumaController extends Controller
 			$filedir .= 'g2f/';
 		}
 
-		$lines = file($filedir."summary.txt");
-		$out = [];
-		foreach($lines as $l){
-			$l = preg_split("/\t/", chop($l));
-			$out[] = [$l[0], $l[1]];
+		$out = [["No sumary table found.","GENE2FUNC Job ID:".$id]];
+		if (file_exists($filedir."summary.txt")) {
+			$lines = file($filedir."summary.txt");
+			$out = [];
+			foreach($lines as $l){
+				$l = preg_split("/\t/", chop($l));
+				$out[] = [$l[0], $l[1]];
+			}
 		}
 		return json_encode($out);
 	}

--- a/public/js/NewJobParameters.js
+++ b/public/js/NewJobParameters.js
@@ -1181,6 +1181,19 @@ function CheckAll(){
 		$('#NewJobCiMapPanel').parent().attr("class", "panel panel-default");
 	}
 
+
+	// GeneTypes
+	table = $("#NewJobGene")["0"];
+	var genetype_count = $("#genetype :selected").length;
+	if(genetype_count==0) {
+		$(table.rows[1].cells[2]).html('<td><div class="alert alert-danger" style="display: table-cell; padding-top:0; padding-bottom:0;">'
+		+'<i class="fa fa-check"></i> Select at least one gene type.</div></td>');
+		submit = false;
+	} else {
+		$(table.rows[1].cells[2]).html('<div class="alert alert-success" style="display: table-cell; padding-top:0; padding-bottom:0;">'
+		+ '<i class="fa fa-check"></i> OK.</div>');
+	}
+
 	//MHC table
 	tablecheck=true;
 	table = $('#NewJobMHC')[0];

--- a/resources/views/browse/newjob.blade.php
+++ b/resources/views/browse/newjob.blade.php
@@ -1662,7 +1662,7 @@
 		</span>
 	</span><br/><br/>
 
-	<input class="btn btn-default" type="submit" value="Submit Job" name="SubmitNewJob" id="SubmitNewJob"/>
+	<input class="btn btn-primary" type="submit" value="Submit Job" name="SubmitNewJob" id="SubmitNewJob"/>
 	<span style="color: red; font-size:18px;">
 		<i class="fa fa-exclamation-triangle"></i> After submitting, please wait a couple of seconds until the file is uploaded, and do not move away from the submission page.
 	</span>

--- a/resources/views/emails/jobError.blade.php
+++ b/resources/views/emails/jobError.blade.php
@@ -62,6 +62,9 @@
 	}else if($status==12){
 		echo ' (Error from circos / <span style="color:blue;"><strong>'.$msg.'</strong></span>)<br/>
 		This error is most likely due to server side error. Please contact the developer for details.<br/>';
+	}else if($status==100){
+		echo ' (Unknown error in job'.$msg.'</strong></span>)<br/>
+		This may be a result of job submission failure, job abort or perhaps a server side error. If this persists please contact the developer for details.<br/>';
 	}
 	?>
 </p>

--- a/resources/views/pages/gene2func.blade.php
+++ b/resources/views/pages/gene2func.blade.php
@@ -205,7 +205,7 @@ var loggedin = "{{ Auth::check() }}";
 
 				<div id="checkGenes"></div>
 				<div id="checkBkGenes"></div>
-				<input type="submit" value="Submit" class="btn btn-default" id="geneSubmit" name="geneSubmit"/><br/><br/>
+				<input type="submit" value="Submit" class="btn btn-primary" id="geneSubmit" name="geneSubmit"/><br/><br/>
 				{!! Form::close() !!}
 			</div>
 

--- a/resources/views/snp2gene/newjob.blade.php
+++ b/resources/views/snp2gene/newjob.blade.php
@@ -942,7 +942,7 @@
 						<span class="info"><i class="fa fa-info"></i> Multiple gene type can be selected.</span>
 					</td>
 					<td>
-						<select multiple class="form-control" name="genetype[]" id="genetype">
+						<select multiple class="form-control" name="genetype[]" id="genetype" onchange="CheckAll();">
 							<option value="all">All</option>
 							<option selected value="protein_coding">Protein coding</option>
 							<option value="lincRNA:antisense:retained_intronic:sense_intronic:sense_overlapping:macro_lncRNA">lncRNA</option>


### PR DESCRIPTION
Several modifications mostly centered around handling the following errors in S2G:

'file_get_contents(/data/fuma/jobs/163055/error.log): failed to open stream: No such file or directory' in /var/www/fuma/app/Jobs/snp2geneProcess.php:85
'parse_ini_file(/data/fuma/jobs/163359/params.config): failed to open stream: No such file or directory' in /var/www/fuma/app/Jobs/snp2geneProcess.php:68

and a case where genetype is empty.

Submit button style has been set to btn-primary (results in a more noticeable Blue button)

